### PR TITLE
Relax binder python requirement

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - gammapy==0.9
-  - python==3.7
+  - python=3.7
   - ipython==7.2.0
   - jupyter==1.0.0
   - jupyterlab==0.35.4
@@ -23,5 +23,6 @@ dependencies:
   - healpy==1.12.8
   - naima==0.8.3
   - ruamel.yaml==0.15.81
+  - pip
   - pip:
     - multinorm==0.2


### PR DESCRIPTION
Binder build fails with:
```
Encountered problems while solving:
  - package libnghttp2-1.51.0-hff17c54_0 requires openssl >=3.0.7,<4.0a0, but none of the providers can be installed

time: 80.980
```

Trying to fix.